### PR TITLE
lint: release versions should be in descending order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,45 @@
 mod debug;
+mod lint;
 mod parse;
+
+use std::{error::Error, fmt::Display};
 
 pub use debug::*;
 pub use parse::*;
+
+use crate::lint::ChangelogLintError;
+
+pub fn parse(source: &str) -> Result<Changelog<'_>, ChangelogCheckError> {
+    let changelog = Changelog::parse(source)?;
+    changelog.lint()?;
+    Ok(changelog)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangelogCheckError {
+    ParseError(ChangelogParseError),
+    LintError(ChangelogLintError),
+}
+
+impl From<ChangelogParseError> for ChangelogCheckError {
+    fn from(value: ChangelogParseError) -> Self {
+        Self::ParseError(value)
+    }
+}
+
+impl From<ChangelogLintError> for ChangelogCheckError {
+    fn from(value: ChangelogLintError) -> Self {
+        Self::LintError(value)
+    }
+}
+
+impl Display for ChangelogCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChangelogCheckError::ParseError(err) => write!(f, "{:?}", err),
+            ChangelogCheckError::LintError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl Error for ChangelogCheckError {}

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -1,0 +1,123 @@
+use std::{error::Error, fmt::Display};
+
+use semver::Version;
+
+use crate::Changelog;
+
+impl<'source> Changelog<'source> {
+    pub fn lint(&self) -> Result<(), ChangelogLintError> {
+        // Check ordering of releases. Could be done during parsing?
+        self.lint_release_version_in_descending_order()?;
+
+        // Check ordering of change sets. Could be done during parsing?
+        // Check ordering of ref defs.
+        // Check links to be of the same form.
+        Ok(())
+    }
+
+    fn lint_release_version_in_descending_order(&self) -> Result<(), ChangelogLintError> {
+        let releases = self.releases();
+        let mut previous_version: Option<&Version> = None;
+        for release in releases {
+            let current = release.version();
+            if let Some(previous) = previous_version
+                && previous <= current
+            {
+                return Err(ChangelogLintError::UnorderedReleases(
+                    previous.clone(),
+                    current.clone(),
+                ));
+            }
+            previous_version = Some(current)
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangelogLintError {
+    UnorderedReleases(Version, Version),
+}
+
+impl Display for ChangelogLintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChangelogLintError::UnorderedReleases(first, second) => write!(
+                f,
+                "expected release version {} to come after {} to respect descending order",
+                first, second
+            ),
+        }
+    }
+}
+
+impl Error for ChangelogLintError {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod lint {
+        use super::*;
+
+        #[test]
+        fn should_error_for_unordered_releases() {
+            let changelog = Changelog::parse(
+                r"# Changelog
+
+This is a mfking changelog y'all.
+
+## [0.2.0] - 2026-01-01
+
+### Added
+
+- Some bull.
+
+## [0.3.0] - 2026-02-04
+
+### Removed
+
+- The bull. 
+
+[0.3.0]: https://github.com/owner/repo/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/owner/repo/releases/tag/v0.2.0",
+            )
+            .unwrap();
+            let result = changelog.lint();
+            assert_eq!(
+                result,
+                Err(ChangelogLintError::UnorderedReleases(
+                    Version::parse("0.2.0").unwrap(),
+                    Version::parse("0.3.0").unwrap()
+                ))
+            );
+        }
+
+        #[test]
+        fn should_work_with_valid_changelog() {
+            let changelog = Changelog::parse(
+                r"# Changelog
+
+This is a mfking changelog y'all.
+
+## [0.2.0] - 2026-02-04
+
+### Removed
+
+- The bull. 
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- Some bull.
+
+[0.2.0]: https://github.com/owner/repo/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/owner/repo/releases/tag/v0.1.0",
+            )
+            .unwrap();
+            let result = changelog.lint();
+            assert_eq!(result, Ok(()));
+        }
+    }
+}

--- a/src/parse/changelog.rs
+++ b/src/parse/changelog.rs
@@ -1,7 +1,8 @@
 use std::{error::Error, fmt::Display};
 
 use crate::parse::{
-    releases::{ChangesParseError, Releases, ReleasesParseError, Unreleased, UnreleasedParseError},
+    ast::Ast,
+    releases::{ChangesParseError, Release, ReleaseParseError, Unreleased, UnreleasedParseError},
     title::{Title, TitleParseError},
 };
 
@@ -13,7 +14,7 @@ pub struct Changelog<'source> {
     /// The unreleased section of a document is optional, as it would basically become empty
     /// after each release. So, whether the user decides to have one or not, is up to them.
     unreleased: Option<Unreleased>,
-    releases: Releases,
+    releases: Vec<Release>,
 }
 
 impl<'source> Changelog<'source> {
@@ -21,7 +22,7 @@ impl<'source> Changelog<'source> {
         source: &'source str,
         title: Title,
         unreleased: Option<Unreleased>,
-        releases: Releases,
+        releases: Vec<Release>,
     ) -> Self {
         Self {
             source,
@@ -43,9 +44,25 @@ impl<'source> Changelog<'source> {
                 }
             },
         };
-        let releases = Releases::parse(&mut ast)?;
+        let mut releases = vec![];
+        loop {
+            match Release::parse(&mut ast) {
+                Ok(release) => releases.push(release),
+                // If we were able to construct at least one release,
+                // we may just be at the end, or reaching the ref defs.
+                Err(_) if !releases.is_empty() => break,
+                // TODO: should there really be this rule?
+                // It is considered an error to not have a single release
+                // at this moment, but that could change.
+                Err(err) => return Err(err.into()),
+            }
+        }
 
         Ok(Changelog::new(source, title, unreleased, releases))
+    }
+
+    pub fn releases(&self) -> &[Release] {
+        &self.releases
     }
 }
 
@@ -55,7 +72,7 @@ pub enum ChangelogParseError {
     // The unreleased parsing can only fail for invalid changes. An invalid heading simply
     // moves on to the releases parsing.
     InvalidUnreleased(ChangesParseError),
-    InvalidReleases(ReleasesParseError),
+    InvalidRelease(ReleaseParseError),
 }
 
 impl From<TitleParseError> for ChangelogParseError {
@@ -64,9 +81,9 @@ impl From<TitleParseError> for ChangelogParseError {
     }
 }
 
-impl From<ReleasesParseError> for ChangelogParseError {
-    fn from(value: ReleasesParseError) -> Self {
-        Self::InvalidReleases(value)
+impl From<ReleaseParseError> for ChangelogParseError {
+    fn from(value: ReleaseParseError) -> Self {
+        Self::InvalidRelease(value)
     }
 }
 
@@ -78,7 +95,7 @@ impl Display for ChangelogParseError {
         match self {
             ChangelogParseError::InvalidTitle(err) => write!(f, "{}", err),
             ChangelogParseError::InvalidUnreleased(err) => write!(f, "{:?}", err),
-            ChangelogParseError::InvalidReleases(err) => write!(f, "{:?}", err),
+            ChangelogParseError::InvalidRelease(err) => write!(f, "{:?}", err),
         }
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -6,7 +6,3 @@ mod title;
 
 pub use changelog::{Changelog, ChangelogParseError};
 // TODO: reexport relevant types.
-
-pub fn parse(source: &str) -> Result<Changelog<'_>, ChangelogParseError> {
-    Changelog::parse(source)
-}

--- a/src/parse/releases/heading.rs
+++ b/src/parse/releases/heading.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use changelog_ast::{Heading, HeadingLevel, Node};
+use semver::Version;
 
 use crate::parse::{
     ast::Ast,
@@ -43,6 +44,10 @@ impl ReleaseHeading {
         };
         let first = ast.pop_front().unwrap().unwrap_heading();
         Ok(ReleaseHeading::new(first.range, info))
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.info.version
     }
 }
 

--- a/src/parse/releases/info.rs
+++ b/src/parse/releases/info.rs
@@ -30,8 +30,9 @@ impl From<DateParseError> for ReleaseInfoParseError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseInfo {
-    version: Version,
-    date: NaiveDate,
+    // TODO: test that prereleases and build meta aren't valid mafock?
+    pub version: Version,
+    pub date: NaiveDate,
 }
 
 impl ReleaseInfo {

--- a/src/parse/releases/mod.rs
+++ b/src/parse/releases/mod.rs
@@ -8,46 +8,5 @@ mod unreleased;
 pub use changes::*;
 pub use heading::*;
 pub use info::*;
+pub use release::*;
 pub use unreleased::*;
-
-use crate::parse::{
-    ast::Ast,
-    releases::release::{Release, ReleaseParseError},
-};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Releases {
-    // TODO: move the logic into Changelog
-    releases: Vec<Release>,
-}
-
-impl Releases {
-    pub fn new(releases: Vec<Release>) -> Self {
-        Self { releases }
-    }
-
-    pub(crate) fn parse(ast: &mut Ast) -> Result<Self, ReleasesParseError> {
-        // TODO: parse unreleased
-
-        let mut releases = vec![];
-        loop {
-            match Release::parse(ast) {
-                Ok(release) => releases.push(release),
-                Err(_) if !releases.is_empty() => return Ok(Self::new(releases)),
-                Err(err) => return Err(err.into()),
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReleasesParseError {
-    // InvalidUnreleased
-    InvalidRelease(ReleaseParseError),
-}
-
-impl From<ReleaseParseError> for ReleasesParseError {
-    fn from(value: ReleaseParseError) -> Self {
-        Self::InvalidRelease(value)
-    }
-}

--- a/src/parse/releases/release.rs
+++ b/src/parse/releases/release.rs
@@ -1,3 +1,5 @@
+use semver::Version;
+
 use crate::parse::{
     ast::Ast,
     releases::{Changes, ChangesParseError, ReleaseHeading, ReleaseHeadingParseError},
@@ -20,6 +22,10 @@ impl Release {
         let changes = Changes::parse(ast)?;
 
         Ok(Release::new(heading, changes))
+    }
+
+    pub fn version(&self) -> &Version {
+        self.heading.version()
     }
 }
 


### PR DESCRIPTION
- Got rid of Releases in favor of Vec<Release> right into the changelog.
- Added a lint to check the order of releases.
