### PR TITLE
refactor: change set kind as implementation detail

### DIFF
--- a/src/parse/releases/change_set.rs
+++ b/src/parse/releases/change_set.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 pub use change::*;
-pub use change_set_kind::*;
+use change_set_kind::*;
 
 use changelog_ast::{HeadingLevel, Node};
 
@@ -82,10 +82,10 @@ mod change_set_kind {
         Changed,
         /// Deprecated items in a change set.
         Deprecated,
-        /// Removed items in a change set.
-        Removed,
         /// Fixed items in a change set.
         Fixed,
+        /// Removed items in a change set.
+        Removed,
         /// Security items in a change set.
         Security,
     }
@@ -199,35 +199,59 @@ pub enum ChangeSetParseError {
     /// When the content of the header does not match our expectations.
     ///
     /// This happens when it doesn't match one of the known strings identifying
-    /// the change set kind. See [ChangeSetKind].
+    /// the change set kind.
     InvalidHeader(Range<usize>),
     InvalidItem(Range<usize>),
     InvalidChangesList(Range<usize>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChangeSet {
-    heading: Range<usize>,
-    items: Vec<Change>,
+pub enum ChangeSet {
+    Added(Added),
+    Changed(Changed),
+    Deprecated(Deprecated),
+    Fixed(Fixed),
+    Removed(Removed),
+    Security(Security),
 }
 
 impl ChangeSet {
-    pub fn new(heading: Range<usize>, items: Vec<Change>) -> Self {
-        Self { heading, items }
-    }
-
-    /// Returns the range covering the whole change set.
     pub fn range(&self) -> Range<usize> {
-        let start = self.heading.start;
-        let end = self
-            .items
-            .last()
-            .map(|c| c.range.end)
-            .unwrap_or(self.heading.end);
-        Range { start, end }
+        match self {
+            ChangeSet::Added(inner) => inner.range(),
+            ChangeSet::Changed(inner) => inner.range(),
+            ChangeSet::Deprecated(inner) => inner.range(),
+            ChangeSet::Fixed(inner) => inner.range(),
+            ChangeSet::Removed(inner) => inner.range(),
+            ChangeSet::Security(inner) => inner.range(),
+        }
     }
 
-    pub(crate) fn parse(ast: &mut Ast) -> Result<(ChangeSetKind, Self), ChangeSetParseError> {
+    pub fn is_added(&self) -> bool {
+        matches!(self, ChangeSet::Added(_))
+    }
+
+    pub fn is_changed(&self) -> bool {
+        matches!(self, ChangeSet::Changed(_))
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        matches!(self, ChangeSet::Deprecated(_))
+    }
+
+    pub fn is_fixed(&self) -> bool {
+        matches!(self, ChangeSet::Fixed(_))
+    }
+
+    pub fn is_removed(&self) -> bool {
+        matches!(self, ChangeSet::Removed(_))
+    }
+
+    pub fn is_security(&self) -> bool {
+        matches!(self, ChangeSet::Security(_))
+    }
+
+    pub(crate) fn parse(ast: &mut Ast) -> Result<Self, ChangeSetParseError> {
         // The first node should be a heading of level 3, and its inner text should equal
         // "Added" verbatim.
         let Some(first) = ast.front() else {
@@ -271,7 +295,29 @@ impl ChangeSet {
         let heading_range = ast.pop_front().unwrap().unwrap_heading().range;
         // Just double checking our assumptions are correct still.
         ast.pop_front().unwrap().unwrap_list();
-        Ok((kind, Self::new(heading_range, items)))
+        Ok((kind, heading_range, items).into())
+    }
+
+    pub(crate) fn is_same_kind(&self, other: &ChangeSet) -> bool {
+        self.is_added() && other.is_added()
+            || self.is_changed() && other.is_changed()
+            || self.is_deprecated() && other.is_deprecated()
+            || self.is_fixed() && other.is_fixed()
+            || self.is_removed() && other.is_removed()
+            || self.is_security() && other.is_security()
+    }
+}
+
+impl From<(ChangeSetKind, Range<usize>, Vec<Change>)> for ChangeSet {
+    fn from(value: (ChangeSetKind, Range<usize>, Vec<Change>)) -> Self {
+        match value.0 {
+            ChangeSetKind::Added => Self::Added(Added::new(value.1, value.2)),
+            ChangeSetKind::Changed => Self::Changed(Changed::new(value.1, value.2)),
+            ChangeSetKind::Deprecated => Self::Deprecated(Deprecated::new(value.1, value.2)),
+            ChangeSetKind::Fixed => Self::Fixed(Fixed::new(value.1, value.2)),
+            ChangeSetKind::Removed => Self::Removed(Removed::new(value.1, value.2)),
+            ChangeSetKind::Security => Self::Security(Security::new(value.1, value.2)),
+        }
     }
 }
 
@@ -284,11 +330,116 @@ mod test {
         let mut ast = Ast::from("### Added\n\n- Some sheeet\n- Big sheet");
         assert_eq!(
             ChangeSet::parse(&mut ast),
-            Ok((
-                ChangeSetKind::Added,
-                ChangeSet::new(0..10, vec![Change::new(11..25), Change::new(25..36)])
-            ))
+            Ok(ChangeSet::Added(Added::new(
+                0..10,
+                vec![Change::new(11..25), Change::new(25..36)]
+            )))
+        );
+        assert!(ast.is_empty());
+    }
+
+    #[test]
+    fn should_work_for_a_valid_changed_change_set() {
+        let mut ast = Ast::from("### Changed\n\n- Some sheeet\n- Big sheet");
+        assert_eq!(
+            ChangeSet::parse(&mut ast),
+            Ok(ChangeSet::Changed(Changed::new(
+                0..12,
+                vec![Change::new(13..27), Change::new(27..38)]
+            )))
+        );
+        assert!(ast.is_empty());
+    }
+
+    #[test]
+    fn should_work_for_a_valid_deprecated_change_set() {
+        let mut ast = Ast::from("### Deprecated\n\n- Some sheeet\n- Big sheet");
+        assert_eq!(
+            ChangeSet::parse(&mut ast),
+            Ok(ChangeSet::Deprecated(Deprecated::new(
+                0..15,
+                vec![Change::new(16..30), Change::new(30..41)]
+            )))
+        );
+        assert!(ast.is_empty());
+    }
+
+    #[test]
+    fn should_work_for_a_valid_fixed_change_set() {
+        let mut ast = Ast::from("### Fixed\n\n- Some sheeet\n- Big sheet");
+        assert_eq!(
+            ChangeSet::parse(&mut ast),
+            Ok(ChangeSet::Fixed(Fixed::new(
+                0..10,
+                vec![Change::new(11..25), Change::new(25..36)]
+            )))
+        );
+        assert!(ast.is_empty());
+    }
+
+    #[test]
+    fn should_work_for_a_valid_removed_change_set() {
+        let mut ast = Ast::from("### Removed\n\n- Some sheeet\n- Big sheet");
+        assert_eq!(
+            ChangeSet::parse(&mut ast),
+            Ok(ChangeSet::Removed(Removed::new(
+                0..12,
+                vec![Change::new(13..27), Change::new(27..38)]
+            )))
+        );
+        assert!(ast.is_empty());
+    }
+
+    #[test]
+    fn should_work_for_a_valid_security_change_set() {
+        let mut ast = Ast::from("### Security\n\n- Some sheeet\n- Big sheet");
+        assert_eq!(
+            ChangeSet::parse(&mut ast),
+            Ok(ChangeSet::Security(Security::new(
+                0..13,
+                vec![Change::new(14..28), Change::new(28..39)]
+            )))
         );
         assert!(ast.is_empty());
     }
 }
+
+macro_rules! ChangeSetVariant {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub struct $name {
+            heading: Range<usize>,
+            items: Vec<Change>,
+        }
+
+        impl $name {
+            pub(crate) fn new(heading: Range<usize>, items: Vec<Change>) -> Self {
+                Self { heading, items }
+            }
+
+            /// Returns the range covering the whole change set.
+            pub fn range(&self) -> Range<usize> {
+                let start = self.heading.start;
+                let end = self
+                    .items
+                    .last()
+                    .map(|c| c.range.end)
+                    .unwrap_or(self.heading.end);
+                start..end
+            }
+        }
+
+        impl From<$name> for ChangeSet {
+            fn from(value: $name) -> Self {
+                Self::$name(value)
+            }
+        }
+    };
+}
+
+ChangeSetVariant!(Added);
+ChangeSetVariant!(Changed);
+ChangeSetVariant!(Deprecated);
+ChangeSetVariant!(Fixed);
+ChangeSetVariant!(Removed);
+ChangeSetVariant!(Security);

--- a/src/parse/releases/changes.rs
+++ b/src/parse/releases/changes.rs
@@ -2,198 +2,50 @@ use std::ops::Range;
 
 use crate::parse::{
     ast::Ast,
-    releases::change_set::{ChangeSet, ChangeSetKind, ChangeSetParseError},
+    releases::change_set::{ChangeSet, ChangeSetParseError},
 };
 
-// TODO: wrap the *OPTION* in new type instead of the inner for clarity.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Changes {
-    added: Option<Added>,
-    changed: Option<Changed>,
-    deprecated: Option<Deprecated>,
-    removed: Option<Removed>,
-    fixed: Option<Fixed>,
-    security: Option<Security>,
+    change_sets: Vec<ChangeSet>,
 }
 
 impl Changes {
-    pub fn try_new(
-        added: Option<Added>,
-        changed: Option<Changed>,
-        deprecated: Option<Deprecated>,
-        removed: Option<Removed>,
-        fixed: Option<Fixed>,
-        security: Option<Security>,
-    ) -> Result<Self, ()> {
-        if added.is_some()
-            || changed.is_some()
-            || deprecated.is_some()
-            || removed.is_some()
-            || fixed.is_some()
-            || security.is_some()
-        {
-            Ok(Self::new(
-                added, changed, deprecated, removed, fixed, security,
-            ))
-        } else {
-            Err(())
-        }
-    }
-
-    /// Returns the range covering the whole set of changes.
-    #[allow(dead_code)]
-    pub fn range(&self) -> Range<usize> {
-        let mut start = usize::MAX;
-        let mut end = usize::MIN;
-        let mut update_range_bounds = |cs: &ChangeSet| {
-            let cs_range = cs.range();
-            if cs_range.start < start {
-                start = cs_range.start;
-            }
-            if cs_range.end > end {
-                end = cs_range.end;
-            }
-        };
-        if let Some(cs) = &self.added {
-            update_range_bounds(&cs.0)
-        }
-        if let Some(cs) = &self.changed {
-            update_range_bounds(&cs.0)
-        }
-        if let Some(cs) = &self.deprecated {
-            update_range_bounds(&cs.0)
-        }
-        if let Some(cs) = &self.removed {
-            update_range_bounds(&cs.0)
-        }
-        if let Some(cs) = &self.fixed {
-            update_range_bounds(&cs.0)
-        }
-        if let Some(cs) = &self.security {
-            update_range_bounds(&cs.0)
-        }
-
-        Range { start, end }
-    }
-
     pub(crate) fn parse(ast: &mut Ast) -> Result<Self, ChangesParseError> {
-        let mut added: Option<Added> = None;
-        let mut changed: Option<Changed> = None;
-        let mut deprecated: Option<Deprecated> = None;
-        let mut removed: Option<Removed> = None;
-        let mut fixed: Option<Fixed> = None;
-        let mut security: Option<Security> = None;
-
-        let duplicate_change_set_err = |kind, first: ChangeSet, second: ChangeSet| {
-            Err(ChangesParseError::DuplicateChangeSet {
-                kind,
-                first: first.range(),
-                second: second.range(),
-            })
-        };
-
+        let mut change_sets: Vec<ChangeSet> = vec![];
         loop {
             match ChangeSet::parse(ast) {
-                Ok((kind, change_set)) => match kind {
-                    ChangeSetKind::Added => match added {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => added = Some(Added(change_set)),
-                    },
-                    ChangeSetKind::Changed => match changed {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => changed = Some(Changed(change_set)),
-                    },
-                    ChangeSetKind::Deprecated => match deprecated {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => deprecated = Some(Deprecated(change_set)),
-                    },
-                    ChangeSetKind::Removed => match removed {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => removed = Some(Removed(change_set)),
-                    },
-                    ChangeSetKind::Fixed => match fixed {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => fixed = Some(Fixed(change_set)),
-                    },
-                    ChangeSetKind::Security => match security {
-                        Some(first) => {
-                            return duplicate_change_set_err(kind, first.0, change_set);
-                        }
-                        _ => security = Some(Security(change_set)),
-                    },
-                },
+                Ok(change_set) => {
+                    if let Some(first) = change_sets.iter().find(|cs| cs.is_same_kind(&change_set))
+                    {
+                        return Err(ChangesParseError::DuplicateChangeSet {
+                            first: first.range(),
+                            second: change_set.range(),
+                        });
+                    }
+                    change_sets.push(change_set);
+                }
                 // An error signals termination, not necessarily that there is an actual error.
                 // There is only an error if no change set could be parsed before the first error.
                 Err(err) => {
-                    return Self::try_new(added, changed, deprecated, removed, fixed, security)
-                        .map_err(|_| err.into());
+                    if change_sets.is_empty() {
+                        return Err(err.into());
+                    } else {
+                        return Ok(Self::new(change_sets));
+                    }
                 }
             }
         }
     }
 
-    fn new(
-        added: Option<Added>,
-        changed: Option<Changed>,
-        deprecated: Option<Deprecated>,
-        removed: Option<Removed>,
-        fixed: Option<Fixed>,
-        security: Option<Security>,
-    ) -> Self {
-        Self {
-            added,
-            changed,
-            deprecated,
-            removed,
-            fixed,
-            security,
-        }
+    fn new(change_sets: Vec<ChangeSet>) -> Self {
+        Self { change_sets }
     }
 }
 
-impl From<Added> for Changes {
-    fn from(value: Added) -> Self {
-        Changes::new(Some(value), None, None, None, None, None)
-    }
-}
-
-impl From<Changed> for Changes {
-    fn from(value: Changed) -> Self {
-        Changes::new(None, Some(value), None, None, None, None)
-    }
-}
-
-impl From<Deprecated> for Changes {
-    fn from(value: Deprecated) -> Self {
-        Changes::new(None, None, Some(value), None, None, None)
-    }
-}
-
-impl From<Removed> for Changes {
-    fn from(value: Removed) -> Self {
-        Changes::new(None, None, None, Some(value), None, None)
-    }
-}
-
-impl From<Fixed> for Changes {
-    fn from(value: Fixed) -> Self {
-        Changes::new(None, None, None, None, Some(value), None)
-    }
-}
-
-impl From<Security> for Changes {
-    fn from(value: Security) -> Self {
-        Changes::new(None, None, None, None, None, Some(value))
+impl<T: Into<ChangeSet>> From<T> for Changes {
+    fn from(value: T) -> Self {
+        Changes::new(vec![value.into()])
     }
 }
 
@@ -201,7 +53,6 @@ impl From<Security> for Changes {
 pub enum ChangesParseError {
     InvalidChangeSet(ChangeSetParseError),
     DuplicateChangeSet {
-        kind: ChangeSetKind,
         first: Range<usize>,
         second: Range<usize>,
     },
@@ -213,63 +64,10 @@ impl From<ChangeSetParseError> for ChangesParseError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Added(ChangeSet);
-
-impl From<ChangeSet> for Added {
-    fn from(value: ChangeSet) -> Self {
-        Added(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Changed(ChangeSet);
-
-impl From<ChangeSet> for Changed {
-    fn from(value: ChangeSet) -> Self {
-        Changed(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Deprecated(ChangeSet);
-
-impl From<ChangeSet> for Deprecated {
-    fn from(value: ChangeSet) -> Self {
-        Deprecated(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Removed(ChangeSet);
-
-impl From<ChangeSet> for Removed {
-    fn from(value: ChangeSet) -> Self {
-        Removed(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Fixed(ChangeSet);
-
-impl From<ChangeSet> for Fixed {
-    fn from(value: ChangeSet) -> Self {
-        Fixed(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Security(ChangeSet);
-
-impl From<ChangeSet> for Security {
-    fn from(value: ChangeSet) -> Self {
-        Security(value)
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use crate::parse::releases::change_set::Change;
+
+    use crate::parse::releases::{Added, Change, Changed, Deprecated, Fixed, Removed, Security};
 
     use super::*;
 
@@ -285,7 +83,6 @@ mod test {
         assert_eq!(
             result,
             Err(ChangesParseError::DuplicateChangeSet {
-                kind: ChangeSetKind::Added,
                 first: 0..18,
                 second: 18..56
             })
@@ -301,10 +98,10 @@ mod test {
 - the stuff you liked
 ### Deprecated
 - the brand new stuff
-### Removed
-- the stuff you needed
 ### Fixed
 - the stuff you didn't care about
+### Removed
+- the stuff you needed
 ### Security
 - ooopsies
 ",
@@ -312,23 +109,14 @@ mod test {
         let result = Changes::parse(&mut ast);
         assert_eq!(
             result,
-            Ok(Changes::new(
-                Some(Added(ChangeSet::new(0..10, vec![Change::new(10..37)]))),
-                Some(Changed(ChangeSet::new(37..49, vec![Change::new(49..71)]))),
-                Some(Deprecated(ChangeSet::new(
-                    71..86,
-                    vec![Change::new(86..108)]
-                ))),
-                Some(Removed(ChangeSet::new(
-                    108..120,
-                    vec![Change::new(120..143)]
-                ))),
-                Some(Fixed(ChangeSet::new(143..153, vec![Change::new(153..187)]))),
-                Some(Security(ChangeSet::new(
-                    187..200,
-                    vec![Change::new(200..211)]
-                ))),
-            ))
+            Ok(Changes::new(vec![
+                Added::new(0..10, vec![Change::new(10..37)]).into(),
+                Changed::new(37..49, vec![Change::new(49..71)]).into(),
+                Deprecated::new(71..86, vec![Change::new(86..108)]).into(),
+                Fixed::new(108..118, vec![Change::new(118..152)]).into(),
+                Removed::new(152..164, vec![Change::new(164..187)]).into(),
+                Security::new(187..200, vec![Change::new(200..211)]).into(),
+            ]))
         );
     }
 }

--- a/src/parse/releases/mod.rs
+++ b/src/parse/releases/mod.rs
@@ -5,6 +5,9 @@ mod info;
 mod release;
 mod unreleased;
 
+// TODO: remove once used in linting.
+#[allow(unused_imports)]
+pub use change_set::*;
 pub use changes::*;
 pub use heading::*;
 pub use info::*;

--- a/src/parse/releases/unreleased.rs
+++ b/src/parse/releases/unreleased.rs
@@ -52,8 +52,8 @@ mod test {
 
     mod parse {
         use crate::parse::releases::{
-            Changed,
-            change_set::{Change, ChangeSet, ChangeSetParseError},
+            Changes,
+            change_set::{Change, ChangeSetParseError, Changed},
         };
 
         use super::*;
@@ -99,7 +99,7 @@ mod test {
                 result,
                 Ok(Unreleased::new(
                     UnreleasedHeading::new(0..16),
-                    Changed::from(ChangeSet::new(17..29, vec![Change::new(29..38)])).into()
+                    Changes::from(Changed::new(17..29, vec![Change::new(29..38)]))
                 ))
             );
         }


### PR DESCRIPTION
- The ChangeSet type is now an enum listing the kinds of change sets.
The smaller enum is still relevant during parsing however, but not more
out of the module.
- The changes now store change sets in the order they were written.
