### PR TITLE
lint: now including unreleased change sets

### DIFF
--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -50,12 +50,24 @@ impl<'source> Changelog<'source> {
     }
 
     fn lint_release_change_sets_in_lexicographical_order(&self) -> Result<(), ChangelogLintError> {
+        if let Some(unreleased) = self.unreleased() {
+            let changes = unreleased.changes();
+            for (previous, current) in changes.iter().map(OrderedChangeSet).tuple_windows() {
+                if previous >= current {
+                    return Err(ChangelogLintError::UnorderedChangeSets(
+                        previous.0.range(),
+                        current.0.range(),
+                    ));
+                }
+            }
+        }
+
         let releases = self.releases();
         for release in releases {
             let changes = release.changes();
             for (previous, current) in changes.iter().map(OrderedChangeSet).tuple_windows() {
                 if previous >= current {
-                    return Err(ChangelogLintError::UnorderedReleaseChangeSets(
+                    return Err(ChangelogLintError::UnorderedChangeSets(
                         previous.0.range(),
                         current.0.range(),
                     ));
@@ -72,7 +84,7 @@ pub enum ChangelogLintError {
     // TODO: store ranges instead?!?!?
     UnorderedReleaseVersions(Version, Version),
     UnorderedReleaseDates(NaiveDate, NaiveDate),
-    UnorderedReleaseChangeSets(Range<usize>, Range<usize>),
+    UnorderedChangeSets(Range<usize>, Range<usize>),
 }
 
 impl Display for ChangelogLintError {
@@ -89,7 +101,7 @@ impl Display for ChangelogLintError {
                 first, second
             ),
             // TODO: prettify
-            ChangelogLintError::UnorderedReleaseChangeSets(first, second) => {
+            ChangelogLintError::UnorderedChangeSets(first, second) => {
                 write!(
                     f,
                     "expected change set {:?} to come after {:?}",
@@ -198,10 +210,34 @@ This is a mfking changelog y'all.
             let result = changelog.lint();
             assert_eq!(
                 result,
-                Err(ChangelogLintError::UnorderedReleaseChangeSets(
-                    73..115,
-                    115..140
-                ))
+                Err(ChangelogLintError::UnorderedChangeSets(73..115, 115..140))
+            );
+        }
+
+        #[test]
+        fn should_error_for_unordered_unreleased_change_sets() {
+            let changelog = Changelog::parse(
+                r"# Changelog
+
+This is a mfking changelog y'all.
+
+## [Unreleased]
+
+### Removed
+
+- The same bull just added.
+
+### Added
+
+- Some bull.
+
+[Unreleased]: https://github.com/owner/repo/releases/tag/v0.1.0",
+            )
+            .unwrap();
+            let result = changelog.lint();
+            assert_eq!(
+                result,
+                Err(ChangelogLintError::UnorderedChangeSets(65..107, 107..132))
             );
         }
 

--- a/src/parse/changelog.rs
+++ b/src/parse/changelog.rs
@@ -7,6 +7,7 @@ use crate::parse::{
 };
 
 // TODO: implement ToOwned
+// TODO: force to have at least an unreleased or a release?
 #[derive(Debug, Clone, PartialEq)]
 pub struct Changelog<'source> {
     source: &'source str,
@@ -48,17 +49,18 @@ impl<'source> Changelog<'source> {
         loop {
             match Release::parse(&mut ast) {
                 Ok(release) => releases.push(release),
-                // If we were able to construct at least one release,
-                // we may just be at the end, or reaching the ref defs.
-                Err(_) if !releases.is_empty() => break,
-                // TODO: should there really be this rule?
-                // It is considered an error to not have a single release
-                // at this moment, but that could change.
+                // If we were able to construct at least one release or we have an
+                // unreleased block, we may just be at the end, or reaching the ref defs.
+                Err(_) if !releases.is_empty() || unreleased.is_some() => break,
                 Err(err) => return Err(err.into()),
             }
         }
 
         Ok(Changelog::new(source, title, unreleased, releases))
+    }
+
+    pub fn unreleased(&self) -> &Option<Unreleased> {
+        &self.unreleased
     }
 
     pub fn releases(&self) -> &[Release] {

--- a/src/parse/releases/unreleased.rs
+++ b/src/parse/releases/unreleased.rs
@@ -17,7 +17,11 @@ pub struct Unreleased {
 }
 
 impl Unreleased {
-    pub fn new(heading: UnreleasedHeading, changes: Changes) -> Self {
+    pub fn changes(&self) -> &Changes {
+        &self.changes
+    }
+
+    pub(crate) fn new(heading: UnreleasedHeading, changes: Changes) -> Self {
         Self { heading, changes }
     }
 


### PR DESCRIPTION
- The previous version did not look at unreleased change sets when
checking their order.
- We don't enforce at least one release anymore. The new rule is now
that the changelog must have at least one release or an unreleased block.
